### PR TITLE
Fix Cloud Build Step 9: use cloud-sdk image for gcloud availability

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,7 +65,7 @@ steps:
         echo "Creating missing export_queue table..."
         gcloud sql connect aqi-development --user=postgres --project=$PROJECT_ID --quiet < create-export-queue.sql || echo "Table creation completed or already exists"
         
-  - name: 'gcr.io/cloud-builders/curl'
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
       - '-c'


### PR DESCRIPTION
- Changed from gcr.io/cloud-builders/curl to gcr.io/google.com/cloudsdktool/cloud-sdk
- Fixes 'gcloud: command not found' error in health check step
- cloud-sdk image includes both gcloud and curl commands