### PR TITLE
Fix Cloud Build: add cloud-sdk image and logging configuration

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,6 +79,7 @@ steps:
 
 options:
   machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
   
 timeout: '1200s'
 


### PR DESCRIPTION
- Step 9: Changed to cloud-sdk image for gcloud availability
- Options: Added CLOUD_LOGGING_ONLY for service account compatibility

Fixes:
- 'gcloud: command not found' error in Step 9
- 'build.service_account requires logging option' error