### PR TITLE
Fix Google authentication: add missing requestId variable declaration

### DIFF
--- a/server/routes/googleAuth.ts
+++ b/server/routes/googleAuth.ts
@@ -11,6 +11,8 @@ const googleAuth = new GoogleAuthService();
 // Initiate basic Google authentication (profile + email only)
 export async function initiateGoogleAuth(req: Request, res: Response) {
   try {
+    const requestId = crypto.randomUUID();
+
     console.log('- Method:', req.method);
     console.log('- URL:', req.url);
     console.log('- Host:', req.headers.host);


### PR DESCRIPTION
This fix adds the requestId declaration that was missing from the main branch. The same fix was previously merged to the merge branch in PR #5, but never made it to main, causing continued authentication failures in production.

Fixes: ReferenceError: requestId is not defined at lines 25, 37 in initiateGoogleAuth

Link to Devin run: https://app.devin.ai/sessions/9c50b3b339414034adc32d708ecb6d19
Requested by: Jerrel (@falcon245sp)