### PR TITLE
feat(outbox): add outbox table DDL and LISTEN/NOTIFY publisher scaffold

### DIFF
--- a/server/outbox/README.md
+++ b/server/outbox/README.md
@@ -1,0 +1,18 @@
+Outbox Publisher (LISTEN/NOTIFY)
+
+- Table: server/outbox/sql/outbox.sql creates an outbox table with pending/publishing/published/failed states, attempts, next_attempt_at, and a LISTEN/NOTIFY trigger (channel: outbox_new) with payload {id, shard}.
+- Shard key: districtId:documentId to preserve per-document ordering while enabling parallelism.
+- Publisher: server/outbox/publisher.ts uses:
+  - LISTEN outbox_new to react to inserts with minimal latency.
+  - Polling fallback every 15s.
+  - 5 retries with exponential backoff; mark failed after exceeding max.
+  - Publishes to Pub/Sub with orderingKey and attributes (eventId, correlationId, version, producer, customerUuid, districtId).
+- DLQ: Stubbed; failures mark the row failed and can be harvested by a future DLQ handler.
+
+Integration notes:
+- Insert outbox rows inside the same DB transaction as domain writes at:
+  1) assessment.uploaded (document creation path)
+  2) analysis.requested (analysis trigger)
+  3) export.requested (export queue creation)
+- Ordering key: documentId where applicable; else a suitable business key.
+- Idempotency: consumers dedupe via eventId/correlationId plus natural keys.

--- a/server/outbox/publisher.ts
+++ b/server/outbox/publisher.ts
@@ -1,0 +1,147 @@
+import { Pool } from 'pg';
+import { PubSub } from '@google-cloud/pubsub';
+
+type OutboxRow = {
+  id: string;
+  topic: string;
+  payload: any;
+  status: 'pending' | 'publishing' | 'published' | 'failed';
+  attempts: number;
+  ordering_key: string | null;
+  event_id: string;
+  correlation_id: string | null;
+  customer_uuid: string;
+  district_id: string;
+  shard_key: string;
+  next_attempt_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+const MAX_RETRIES = parseInt(process.env.OUTBOX_MAX_RETRIES || '5', 10);
+const BACKOFF_BASE_MS = parseInt(process.env.OUTBOX_BACKOFF_BASE_MS || '2000', 10);
+const POLL_INTERVAL_MS = parseInt(process.env.OUTBOX_POLL_INTERVAL_MS || '15000', 10);
+
+export class OutboxPublisher {
+  private pool: Pool;
+  private pubsub: PubSub;
+  private stop = false;
+
+  constructor(pool: Pool, pubsub?: PubSub) {
+    this.pool = pool;
+    this.pubsub = pubsub || new PubSub();
+  }
+
+  async start() {
+    const client = await this.pool.connect();
+    try {
+      await client.query('LISTEN outbox_new');
+      client.on('notification', (msg) => {
+        if (msg.channel === 'outbox_new') {
+          this.processAvailable().catch(() => {});
+        }
+      });
+    } finally {
+      client.release();
+    }
+    this.loopPoll();
+  }
+
+  stopSync() {
+    this.stop = true;
+  }
+
+  private async loopPoll() {
+    while (!this.stop) {
+      try {
+        await this.processAvailable();
+      } catch {}
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+  }
+
+  private async processAvailable() {
+    let row: OutboxRow | null;
+    while ((row = await this.leaseOne())) {
+      try {
+        await this.publishRow(row);
+        await this.markPublished(row.id);
+      } catch (err) {
+        await this.handleFailure(row.id, row.attempts);
+      }
+    }
+  }
+
+  private async leaseOne(): Promise<OutboxRow | null> {
+    const sql = `
+      WITH cte AS (
+        SELECT id
+        FROM outbox
+        WHERE status = 'pending'
+          AND next_attempt_at <= now()
+        ORDER BY created_at
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1
+      )
+      UPDATE outbox o
+      SET status = 'publishing', updated_at = now()
+      FROM cte
+      WHERE o.id = cte.id
+      RETURNING o.*;
+    `;
+    const res = await this.pool.query(sql);
+    if (res.rowCount === 0) return null;
+    return res.rows[0] as OutboxRow;
+  }
+
+  private async publishRow(row: OutboxRow) {
+    const dataBuffer = Buffer.from(JSON.stringify(row.payload));
+    const attributes: Record<string, string> = {
+      eventId: row.event_id,
+      correlationId: row.correlation_id || '',
+      customerUuid: row.customer_uuid,
+      districtId: row.district_id,
+      version: 'v1',
+      producer: 'SBG-with-AQI',
+      shardKey: row.shard_key,
+    };
+
+    const topic = this.pubsub.topic(row.topic, {
+      messageOrdering: !!row.ordering_key,
+    });
+
+    await topic.publishMessage({
+      data: dataBuffer,
+      orderingKey: row.ordering_key || undefined,
+      attributes,
+    });
+  }
+
+  private async markPublished(id: string) {
+    await this.pool.query(
+      `UPDATE outbox SET status='published', updated_at=now() WHERE id=$1`,
+      [id]
+    );
+  }
+
+  private async handleFailure(id: string, attempts: number) {
+    const nextAttempts = attempts + 1;
+    const backoff = Math.pow(2, attempts) * BACKOFF_BASE_MS;
+    if (nextAttempts >= MAX_RETRIES) {
+      await this.pool.query(
+        `UPDATE outbox SET status='failed', attempts=$2, updated_at=now() WHERE id=$1`,
+        [id, nextAttempts]
+      );
+      return;
+    }
+    await this.pool.query(
+      `UPDATE outbox
+         SET attempts=$2,
+             status='pending',
+             next_attempt_at=now() + make_interval(secs => $3 / 1000.0),
+             updated_at=now()
+       WHERE id=$1`,
+      [id, nextAttempts, backoff]
+    );
+  }
+}

--- a/server/outbox/sql/outbox.sql
+++ b/server/outbox/sql/outbox.sql
@@ -1,0 +1,32 @@
+
+CREATE TABLE IF NOT EXISTS outbox (
+  id uuid PRIMARY KEY,
+  topic text NOT NULL,
+  payload jsonb NOT NULL,
+  status text NOT NULL DEFAULT 'pending', -- pending|publishing|published|failed
+  attempts int NOT NULL DEFAULT 0,
+  ordering_key text,
+  event_id uuid UNIQUE NOT NULL,
+  correlation_id text,
+  customer_uuid text NOT NULL,
+  district_id text NOT NULL,
+  shard_key text NOT NULL, -- districtId:documentId
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_status_next ON outbox (status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_outbox_shard_status ON outbox (shard_key, status);
+CREATE INDEX IF NOT EXISTS idx_outbox_created ON outbox (created_at);
+
+CREATE OR REPLACE FUNCTION notify_outbox_insert() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('outbox_new', json_build_object('id', NEW.id, 'shard', NEW.shard_key)::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS outbox_notify ON outbox;
+CREATE TRIGGER outbox_notify AFTER INSERT ON outbox
+FOR EACH ROW EXECUTE FUNCTION notify_outbox_insert();


### PR DESCRIPTION
# Add outbox table DDL and LISTEN/NOTIFY publisher scaffold

## Summary
Adds the foundational infrastructure for the outbox pattern to enable reliable event publishing from the monolith to microservices. This is **scaffold code only** - it sets up the database table, trigger, and publisher worker but does not yet integrate with domain logic to actually publish events.

**Key components:**
- **Outbox table DDL** with PostgreSQL LISTEN/NOTIFY trigger for low-latency processing  
- **Publisher worker class** using LISTEN + polling fallback, exponential backoff, and Pub/Sub integration
- **Shard key strategy**: `districtId:documentId` for per-document ordering with parallelism
- **Retry policy**: 5 attempts with exponential backoff, then mark failed

## Review & Testing Checklist for Human

- [ ] **Database Schema Review**: Validate SQL DDL correctness, index efficiency, and trigger behavior in `server/outbox/sql/outbox.sql`
- [ ] **Concurrency Safety**: Review publisher leasing logic and LISTEN/NOTIFY handling for race conditions or deadlocks
- [ ] **Error Handling**: Verify retry logic, backoff calculation, and failure state transitions are robust
- [ ] **Resource Management**: Ensure LISTEN connection and polling loop have proper cleanup mechanisms
- [ ] **Integration Planning**: Confirm this scaffold aligns with planned domain code integration points (document creation, analysis trigger, export queue)

### Notes
- Missing dependency: `@google-cloud/pubsub` needs to be installed
- No unit tests included - critical for infrastructure components  
- Ready for integration: Next step is adding transactional outbox inserts in domain write operations
- Link to Devin run: https://app.devin.ai/sessions/6124c2b43fb34576b19fd6b4eac6328d
- Requested by: Jerrel (@falcon245sp)